### PR TITLE
Add ability to set Secure and HttpOnly flags, fixes #1 and #2

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -61,7 +61,7 @@ func SecureCookie(req *http.Request, name string, cookieSecret string) (string, 
 
 // Set a cookie with an explicit path.
 // age is the time-to-live, in seconds (0 means forever).
-func SetCookiePath(w http.ResponseWriter, name, value string, age int64, path string) {
+func SetCookiePath(w http.ResponseWriter, name, value string, age int64, path string, secure, httponly bool) {
 	var utctime time.Time
 	if age == 0 {
 		// 2^31 - 1 seconds (roughly 2038)
@@ -69,7 +69,7 @@ func SetCookiePath(w http.ResponseWriter, name, value string, age int64, path st
 	} else {
 		utctime = time.Unix(time.Now().Unix()+age, 0)
 	}
-	cookie := http.Cookie{Name: name, Value: value, Expires: utctime, Path: path}
+	cookie := http.Cookie{Name: name, Value: value, Expires: utctime, Path: path, Secure: secure, HttpOnly: httponly}
 	SetHeader(w, "Set-Cookie", cookie.String(), false)
 }
 
@@ -83,7 +83,7 @@ func ClearCookie(w http.ResponseWriter, cookieName, cookiePath string) {
 
 // Set a secure cookie with an explicit path.
 // age is the time-to-live, in seconds (0 means forever).
-func SetSecureCookiePath(w http.ResponseWriter, name, val string, age int64, path string, cookieSecret string) {
+func SetSecureCookiePath(w http.ResponseWriter, name, val string, age int64, path string, cookieSecret string, secure, httponly bool) {
 	// base64 encode the value
 	if len(cookieSecret) == 0 {
 		log.Fatalln("Secret Key for secure cookies has not been set. Please use a non-empty secret.")
@@ -97,7 +97,7 @@ func SetSecureCookiePath(w http.ResponseWriter, name, val string, age int64, pat
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
 	sig := CookieSig(cookieSecret, vb, timestamp)
 	cookie := strings.Join([]string{vs, timestamp, sig}, "|")
-	SetCookiePath(w, name, cookie, age, path)
+	SetCookiePath(w, name, cookie, age, path, secure, httponly)
 }
 
 // Get the cookie signature

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -1,7 +1,10 @@
 package cookie
 
 import (
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -15,4 +18,92 @@ func TestSecureCookieFormat(t *testing.T) {
 		t.Fatalf("TestSecureCookieFormat expected false instead %v", ok)
 	}
 
+}
+
+func cookiePartInSlice(cookieSlice []string, part string) bool {
+	for i := range cookieSlice {
+		entry := strings.TrimSpace(cookieSlice[i])
+		if entry == part {
+			return true
+		}
+	}
+	return false
+}
+
+type SetCookieTest struct {
+	name     string
+	value    string
+	age      int64
+	path     string
+	secret   string
+	secure   bool
+	httponly bool
+}
+
+// SetSecureCookiePath can set cookies with different flags
+func TestSetSecureCookiePath(t *testing.T) {
+	tests := []SetCookieTest{
+		SetCookieTest{
+			name:     "username",
+			value:    "foo",
+			age:      int64(3600),
+			path:     "/",
+			secret:   "12345secret",
+			secure:   false,
+			httponly: false,
+		},
+		SetCookieTest{
+			name:     "username",
+			value:    "foo",
+			age:      int64(3600),
+			path:     "/",
+			secret:   "12345secret",
+			secure:   true,
+			httponly: false,
+		},
+		SetCookieTest{
+			name:     "username",
+			value:    "foo",
+			age:      int64(3600),
+			path:     "/",
+			secret:   "12345secret",
+			secure:   false,
+			httponly: true,
+		},
+		SetCookieTest{
+			name:     "username",
+			value:    "foo",
+			age:      int64(3600),
+			path:     "/",
+			secret:   "12345secret",
+			secure:   true,
+			httponly: true,
+		},
+	}
+
+	for _, test := range tests {
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			SetSecureCookiePath(w, test.name, test.value, test.age, test.path, test.secret, test.secure, test.httponly)
+			io.WriteString(w, "testing..")
+		}
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		cookie := resp.Header.Get("Set-Cookie")
+
+		cookieSlice := strings.Split(cookie, ";")
+		httpOnlyExists := cookiePartInSlice(cookieSlice, "HttpOnly")
+		if httpOnlyExists != test.httponly {
+			t.Logf("In test case: %+v\n", test)
+			t.Fatalf("TestSetSecureCookiePath expected HttpOnly to be set, it isn't, Cookie: %s", cookie)
+		}
+		secureExists := cookiePartInSlice(cookieSlice, "Secure")
+		if secureExists != test.secure {
+			t.Logf("In test case: %+v\n", test)
+			t.Fatalf("TestSetSecureCookiePath expected Secure to be set, it isn't, Cookie: %s", cookie)
+		}
+	}
 }


### PR DESCRIPTION
Add ability to set Secure and HttpOnly flags. It's a straight forward change, but it break compatibility as it adds arguments. 

Fixes #1 and #2

Also added a test case, which probably can  be extended to verify other things in the requets.
